### PR TITLE
add plot method using matplotlib

### DIFF
--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -100,5 +100,65 @@ def padded_squarify(sizes, x, y, dx, dy):
     for rect in rects:
         pad_rectangle(rect)
     return rects
+
+def plot(sizes, norm_x=100, norm_y=100,
+         color=None, label=None, value=None,
+         ax=None, **kwargs):
+
+    """
+    Plotting with Matplotlib.
+
+    Parameters
+    ----------
+    sizes: input for squarify
+    norm_x, norm_y: x and y values for normalization
+    color: color string or list-like (see Matplotlib documentation for details)
+    label: list-like used as label text
+    value: list-like used as value text (in most cases identical with sizes argument)
+    ax: Matplotlib Axes instance
+    kwargs: dict, keyword arguments passed to matplotlib.Axes.bar
+
+    Returns
+    -------
+    axes: Matplotlib Axes
+    """
     
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        ax = plt.gca()
+
+    if color is None:
+        import matplotlib.cm
+        import random
+        cmap = matplotlib.cm.get_cmap()
+        color = [cmap(random.random()) for i in range(len(sizes))]
+
+    normed = normalize_sizes(sizes, norm_x, norm_y)
+    rects = squarify(normed, 0, 0, norm_x, norm_y)
+    
+    x = [rect['x'] for rect in rects]
+    y = [rect['y'] for rect in rects]
+    dx = [rect['dx'] for rect in rects]
+    dy = [rect['dy'] for rect in rects]
+
+    ax.bar(x, dy, width=dx, bottom=y, color=color,
+       label=label, **kwargs)
+
+    if not value is None:
+        va = 'center' if label is None else 'top'
+            
+        for v, r in zip(value, rects):
+            x, y, dx, dy = r['x'], r['y'], r['dx'], r['dy']
+            ax.text(x + dx / 2, y + dy / 2, v, va=va, ha='center')
+
+    if not label is None:
+        va = 'center' if value is None else 'bottom'
+        for l, r in zip(label, rects):
+            x, y, dx, dy = r['x'], r['y'], r['dx'], r['dy']
+            ax.text(x + dx / 2, y + dy / 2, l, va=va, ha='center')
+
+    ax.set_xlim(0, norm_x)
+    ax.set_ylim(0, norm_y)
+    return ax 
     


### PR DESCRIPTION
Added `plot` method using matplotlib. Matplotlib is imported in the `plot` method and it should not affect to dependencies.

_Usage Example:_

```
import squarify
import matplotlib.pyplot as plt
from numpy.random import rand

fig, axes = plt.subplots(2, 3, figsize=(14, 8))
plt.subplots_adjust(top=0.95, bottom=0.05, left=0.05, right=0.95, hspace=0.35)

sq = 8

def random_colors(n):
    return zip(rand(n), rand(n), rand(n))

labels = ['Sq{0}'.format(i) for i in range(sq)]

axes[0, 0].set_title('Default')
squarify.plot(rand(sq), ax=axes[0, 0])

axes[0, 1].set_title('Specify single color')
squarify.plot(rand(sq), color='r', ax=axes[0, 1])

axes[0, 2].set_title('Specify each colors')
squarify.plot(rand(sq), color=random_colors(sq), ax=axes[0, 2])

axes[1, 0].set_title('Specify labels')
squarify.plot(rand(sq), label=labels, ax=axes[1, 0])

sizes = rand(sq)
values = ['{0:0.2f}'.format(s) for s in sizes]
axes[1, 1].set_title('Specify values')
squarify.plot(sizes, value=values, ax=axes[1, 1])

axes[1, 2].set_title('Specify labels and values')
squarify.plot(sizes, label=labels, value=values, ax=axes[1, 2])
plt.show()
```

_Output:_
![squarify_plot](https://f.cloud.github.com/assets/1696302/2430332/23b4e2a8-acd3-11e3-871b-52ec45a764b9.png)
