### PR TITLE
Python3 compatibility, evaluated maps to lists.

### DIFF
--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -7,7 +7,7 @@ def normalize_sizes(sizes, dx, dy):
     total_area = dx * dy
     sizes = map(float, sizes)
     sizes = map(lambda size: size * total_area / total_size, sizes)
-    return sizes
+    return list(sizes)
 
 def pad_rectangle(rect):
     if rect['dx'] > 2:
@@ -76,7 +76,7 @@ def squarify(sizes, x, y, dx, dy):
     # sizes should be pre-normalized wrt dx * dy (i.e., they should be same units)
     # or dx * dy == sum(sizes)
     # sizes should be sorted biggest to smallest
-    sizes = map(float, sizes)
+    sizes = list(map(float, sizes))
     
     if len(sizes) == 0:
         return []


### PR DESCRIPTION
The example code didn't run since `map` evaluates to a generator rather than a list on Python 3. Now it does.