### PR TITLE
map() to list() for python3 compability

### DIFF
--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -7,7 +7,7 @@ def normalize_sizes(sizes, dx, dy):
     total_area = dx * dy
     sizes = map(float, sizes)
     sizes = map(lambda size: size * total_area / total_size, sizes)
-    return sizes
+    return list(sizes)
 
 def pad_rectangle(rect):
     if rect['dx'] > 2:
@@ -76,7 +76,7 @@ def squarify(sizes, x, y, dx, dy):
     # sizes should be pre-normalized wrt dx * dy (i.e., they should be same units)
     # or dx * dy == sum(sizes)
     # sizes should be sorted biggest to smallest
-    sizes = map(float, sizes)
+    sizes = list(map(float, sizes))
     
     if len(sizes) == 0:
         return []


### PR DESCRIPTION
Converts maps to lists, due to the fact python3 map() returns generators.