### PR TITLE
Fix matplotlib 2.0 compat

### DIFF
--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -143,7 +143,7 @@ def plot(sizes, norm_x=100, norm_y=100,
     dy = [rect['dy'] for rect in rects]
 
     ax.bar(x, dy, width=dx, bottom=y, color=color,
-       label=label, **kwargs)
+       label=label, align='edge', **kwargs)
 
     if not value is None:
         va = 'center' if label is None else 'top'


### PR DESCRIPTION
bar() default behaviour changed with matplotlib 2.0 (see http://matplotlib.org/users/dflt_style_changes.html#plotting-functions)
Patch forces old (and expected) bar alignment.