### PR TITLE
Use official OSI naming for the Apache 2.0 license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Uri Laserson",
     author_email="uri.laserson@gmail.com",
     description="Pure Python implementation of the squarify treemap layout algorithm",
-    license="Apache v2",
+    license="Apache License 2.0",
     keywords="treemap visualization squarify layout graphics",
     classifiers=[
         "Programming Language :: Python :: 2.6",


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.