### PR TITLE
Plot subgroup treemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Normalizes a list of numeric values so that `sum(sizes) == dx * dy`.
 
 **Parameters**
 
-    sizes : (nested-)list-like of numeric values
+    sizes : list-like of numeric values
         Input list of numeric values to normalize.
     dx, dy : numeric
         The dimensions of the full rectangle to normalize total values to.
@@ -205,7 +205,7 @@ See README for example usage.
 
 **Parameters**
 
-    sizes : (nested-)list-like of numeric values
+    sizes : list-like of numeric values
         The set of values to compute a treemap for. `sizes` must be positive
         values sorted in descending order and they should be normalized to the
         total area (i.e., `dx * dy == sum(sizes)`)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ implements it differently.
 
 ## Contents
 
-* [Installation](#Installation)
-* [Usage](#Usage)
-* [Example](#Example)
-* [Documentation](#Documentation-for-Squarify)
+- [squarify](#squarify)
+  - [Contents](#contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Example](#example)
+  - [Documentation for Squarify](#documentation-for-squarify)
 
 Installation
 ------------
@@ -140,7 +142,7 @@ Normalizes a list of numeric values so that `sum(sizes) == dx * dy`.
 
 **Parameters**
 
-    sizes : list-like of numeric values
+    sizes : (nested-)list-like of numeric values
         Input list of numeric values to normalize.
     dx, dy : numeric
         The dimensions of the full rectangle to normalize total values to.
@@ -203,7 +205,7 @@ See README for example usage.
 
 **Parameters**
 
-    sizes : list-like of numeric values
+    sizes : (nested-)list-like of numeric values
         The set of values to compute a treemap for. `sizes` must be positive
         values sorted in descending order and they should be normalized to the
         total area (i.e., `dx * dy == sum(sizes)`)


### PR DESCRIPTION
Hello team,

I think it would be great if the `plot` function allows plotting subgroup treemap by passing a nested list to the argument `sizes`. I edit this `function` to add this feature. Here is a short snippet for generating the subgroup treemap:

```python
import squarify

data = [[12,  9,  5],
        [ 3,  5,  8],
        [ 4,  1,  2]]

_, axes = plt.subplots(1, 2, figsize=(10, 5))
squarify.plot(sizes=np.array(data).flatten(),
              color=['#ABAB7B']*3 + ['#707000']*3 + ['#DCDCC3']*3,
              norm_x=200,
              norm_y=200,
              pad=True,
              ax=axes[0])
axes[0].set_title('Squarify without subgroups')
axes[0].axis('off')

squarify.plot(sizes=data,
              color=['#ABAB7B']*3 + ['#707000']*3 + ['#DCDCC3']*3,
              norm_x=200,
              norm_y=150,
              pad=True,
              ax=axes[1])
axes[1].set_title('Squarify with subgroups')
axes[1].axis('off')
```
Output:
![](https://github.com/nguyenhoa93/dataviz-python/raw/master/assets/squarify.png)