### PR TITLE
Allow to specify text (label and/or value) location inside rectangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,54 +160,29 @@ returned rectangles have been "padded" to allow for a visible border.
 
 ----------------------------------------------------------------------------------------
 
-`plot(sizes, norm_x=100, norm_y=100, color=None, label=None, value=None, loc=None, ax=None, pad=False, bar_kwargs=None, text_kwargs=None, **kwargs)`
+`plot(sizes, norm_x=100, norm_y=100, color=None, label=None, value=None, ax=None, pad=False, bar_kwargs=None, text_kwargs=None, **kwargs)`
 :   Plotting with Matplotlib.
 
 **Parameters**
 
-    sizes : 
+    sizes
         input for squarify
-
-    norm_x, norm_y :
+    norm_x, norm_y
         x and y values for normalization
-
-    color :
+    color
         color string or list-like (see Matplotlib documentation for details)
-
-    label :
+    label
         list-like used as label text
-
-    value :
+    value
         list-like used as value text (in most cases identical with sizes argument)
-
-    loc :
-        The location of the texts (labels and/or values) inside the rectangles.
-
-        The strings
-        ``'upper left', 'upper right', 'lower left', 'lower right'``
-        place the text at the corresponding corner of the rectangles.
-
-        The strings
-        ``'upper center', 'lower center', 'center left', 'center right'``
-        place the text at the center of the corresponding edge of the
-        rectangles.
-
-        The string ``'center'`` places the text at the center of the rectangles.
-
-        ``NoneType`` defaults to ``'center'``.
-
-    ax :
+    ax
         Matplotlib Axes instance
-
-    pad :
+    pad
         draw rectangles with a small gap between them
-
     bar_kwargs : dict
         keyword arguments passed to matplotlib.Axes.bar
-
     text_kwargs : dict
         keyword arguments passed to matplotlib.Axes.text
-
     **kwargs
         Any additional kwargs are merged into `bar_kwargs`. Explicitly provided
         kwargs here will take precedence.

--- a/README.md
+++ b/README.md
@@ -160,29 +160,54 @@ returned rectangles have been "padded" to allow for a visible border.
 
 ----------------------------------------------------------------------------------------
 
-`plot(sizes, norm_x=100, norm_y=100, color=None, label=None, value=None, ax=None, pad=False, bar_kwargs=None, text_kwargs=None, **kwargs)`
+`plot(sizes, norm_x=100, norm_y=100, color=None, label=None, value=None, loc=None, ax=None, pad=False, bar_kwargs=None, text_kwargs=None, **kwargs)`
 :   Plotting with Matplotlib.
 
 **Parameters**
 
-    sizes
+    sizes : 
         input for squarify
-    norm_x, norm_y
+
+    norm_x, norm_y :
         x and y values for normalization
-    color
+
+    color :
         color string or list-like (see Matplotlib documentation for details)
-    label
+
+    label :
         list-like used as label text
-    value
+
+    value :
         list-like used as value text (in most cases identical with sizes argument)
-    ax
+
+    loc :
+        The location of the texts (labels and/or values) inside the rectangles.
+
+        The strings
+        ``'upper left', 'upper right', 'lower left', 'lower right'``
+        place the text at the corresponding corner of the rectangles.
+
+        The strings
+        ``'upper center', 'lower center', 'center left', 'center right'``
+        place the text at the center of the corresponding edge of the
+        rectangles.
+
+        The string ``'center'`` places the text at the center of the rectangles.
+
+        ``NoneType`` defaults to ``'center'``.
+
+    ax :
         Matplotlib Axes instance
-    pad
+
+    pad :
         draw rectangles with a small gap between them
+
     bar_kwargs : dict
         keyword arguments passed to matplotlib.Axes.bar
+
     text_kwargs : dict
         keyword arguments passed to matplotlib.Axes.text
+
     **kwargs
         Any additional kwargs are merged into `bar_kwargs`. Explicitly provided
         kwargs here will take precedence.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Uri Laserson",
     author_email="uri.laserson@gmail.com",
     description="Pure Python implementation of the squarify treemap layout algorithm",
-    license="Apache License 2.0",
+    license="Apache v2",
     keywords="treemap visualization squarify layout graphics",
     classifiers=[
         "Programming Language :: Python :: 2.6",

--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -182,7 +182,7 @@ def plot(
     color=None,
     label=None,
     value=None,
-    align=None,
+    loc=None,
     ax=None,
     pad=False,
     bar_kwargs=None,
@@ -203,6 +203,8 @@ def plot(
         list-like used as label text
     value
         list-like used as value text (in most cases identical with sizes argument)
+    loc
+        string that specifies text (label and/or value) location inside rectangles
     ax
         Matplotlib Axes instance
     pad
@@ -267,35 +269,35 @@ def plot(
         for text, rect in zip(texts, rects):
             x, y, dx, dy = rect["x"], rect["y"], rect["dx"], rect["dy"]
 
-            # Text alignment
-            if align == "center":
+            # Text location
+            if loc == "center":
                 h_offset = dx / 2
                 v_offset = dy / 2
                 va = "center"
                 ha = "center"
             else:
-                match = re.match(r"([a-z]+) ([a-z]+)", align)
-                v_align, h_align = match.groups()
+                match = re.match(r"([a-z]+) ([a-z]+)", loc)
+                v_loc, h_loc = match.groups()
 
-                # Vertical alignment
-                if v_align == 'top':
+                # Vertical location
+                if v_loc == 'top':
                     va = "top"
                     v_offset = dy - 1
-                elif v_align == 'center':
+                elif v_loc == 'center':
                     va = "center"
                     v_offset = dy / 2
-                elif v_align == 'bottom':
+                elif v_loc == 'bottom':
                     va = "bottom"
                     v_offset = 1
 
-                # Horizontal alignment
-                if h_align == 'left':
+                # Horizontal location
+                if h_loc == 'left':
                     ha = "left"
                     h_offset = 1
-                elif h_align == 'center':
+                elif h_loc == 'center':
                     ha = "center"
                     h_offset = dx / 2
-                elif h_align == 'right':
+                elif h_loc == 'right':
                     ha = "right"
                     h_offset = dx - 1
 

--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -5,11 +5,6 @@
 
 # INTERNAL FUNCTIONS not meant to be used by the user
 
-import re
-
-_location_error_message = "Invalid location string: '%s'."
-
-
 def pad_rectangle(rect):
     if rect["dx"] > 2:
         rect["x"] += 1
@@ -312,9 +307,9 @@ def plot(
             va, ha = "center", "center"
         else:
             va, ha = loc.split()
-            if va not in {"top", "center", "bottom"}:
+            if va not in _v_offsets.keys():
                 raise ValueError(f"Invalid `loc` string: {loc}")
-            if ha not in {"left", "center", "right"}:
+            if ha not in _h_offsets.keys():
                 raise ValueError(f"Invalid `loc` string: {loc}")
 
         # Add the annot

--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -7,6 +7,9 @@
 
 import re
 
+_location_error_message = "Invalid location string: '%s'."
+
+
 def pad_rectangle(rect):
     if rect["dx"] > 2:
         rect["x"] += 1
@@ -193,26 +196,49 @@ def plot(
 
     Parameters
     ----------
-    sizes
+    sizes :
         input for squarify
-    norm_x, norm_y
+
+    norm_x, norm_y :
         x and y values for normalization
-    color
+
+    color :
         color string or list-like (see Matplotlib documentation for details)
-    label
+
+    label :
         list-like used as label text
-    value
+
+    value :
         list-like used as value text (in most cases identical with sizes argument)
-    loc
-        string that specifies text (label and/or value) location inside rectangles
-    ax
+
+    loc :
+        The location of the texts (labels and/or values) inside the rectangles.
+
+        The strings
+        ``'upper left', 'upper right', 'lower left', 'lower right'``
+        place the text at the corresponding corner of the rectangles.
+
+        The strings
+        ``'upper center', 'lower center', 'center left', 'center right'``
+        place the text at the center of the corresponding edge of the
+        rectangles.
+
+        The string ``'center'`` places the text at the center of the rectangles.
+
+        ``NoneType`` defaults to ``'center'``.
+
+    ax :
         Matplotlib Axes instance
-    pad
+
+    pad :
         draw rectangles with a small gap between them
+
     bar_kwargs : dict
         keyword arguments passed to matplotlib.Axes.bar
+
     text_kwargs : dict
         keyword arguments passed to matplotlib.Axes.text
+
     **kwargs
         Any additional kwargs are merged into `bar_kwargs`. Explicitly provided
         kwargs here will take precedence.
@@ -270,36 +296,43 @@ def plot(
             x, y, dx, dy = rect["x"], rect["y"], rect["dx"], rect["dy"]
 
             # Text location
-            if loc == "center":
+            if (loc is None) or (loc == "center"):
                 h_offset = dx / 2
                 v_offset = dy / 2
                 va = "center"
                 ha = "center"
             else:
                 match = re.match(r"([a-z]+) ([a-z]+)", loc)
-                v_loc, h_loc = match.groups()
+                try:
+                    v_loc, h_loc = match.groups()
+                except AttributeError as e:
+                    raise ValueError(_location_error_message % loc)
 
                 # Vertical location
-                if v_loc == 'top':
+                if v_loc == "upper":
                     va = "top"
                     v_offset = dy - 1
-                elif v_loc == 'center':
+                elif v_loc == "center":
                     va = "center"
                     v_offset = dy / 2
-                elif v_loc == 'bottom':
+                elif v_loc == "lower":
                     va = "bottom"
                     v_offset = 1
+                else:
+                    raise ValueError(_location_error_message % loc)
 
                 # Horizontal location
-                if h_loc == 'left':
+                if h_loc == "left":
                     ha = "left"
                     h_offset = 1
-                elif h_loc == 'center':
+                elif h_loc == "center":
                     ha = "center"
                     h_offset = dx / 2
-                elif h_loc == 'right':
+                elif h_loc == "right":
                     ha = "right"
                     h_offset = dx - 1
+                else:
+                    raise ValueError(_location_error_message % loc)
 
             ax.text(x + h_offset, y + v_offset, text, va=va, ha=ha, **text_kwargs)
 


### PR DESCRIPTION
Hello team,

I found it useful to modify the `plot` function by adding a `loc` argument that allows the user to specify the desired location of text inside the rectangles. Until now this location was always the center of the rectangles.

For instance:

```python
import squarify
import matplotlib.pyplot as plt

labels = ['A', 'B', 'C', 'D', 'E']
values = [500.0, 433.0, 78.0, 25.0, 25.0]

fig, axes = plt.subplots(1, 1)
ax = squarify.plot(sizes=values,
              pad=True,
              ax=axes,
              label=labels,
              value=values,
              loc="top left",
              )
ax.axis("off")

fig, axes = plt.subplots(1, 1)
ax = squarify.plot(sizes=values,
              pad=True,
              ax=axes,
              label=labels,
              value=values,
              loc="center",
              )
ax.axis("off")

fig, axes = plt.subplots(1, 1)
ax = squarify.plot(sizes=values,
              pad=True,
              ax=axes,
              label=labels,
              value=values,
              loc="bottom right",
              )
ax.axis("off")

plt.show()
```
Output:
![Figure_1](https://user-images.githubusercontent.com/7562065/187098025-7854dc24-2585-4e06-9738-f85c70b9f363.png)
![Figure_2](https://user-images.githubusercontent.com/7562065/187098026-5bcb0d77-ebdb-4bf0-9d10-81fbff0f567f.png)
![Figure_3](https://user-images.githubusercontent.com/7562065/187098027-c70f5658-07c3-4f36-8aa1-f73fcccca33c.png)