### PR TITLE
Add `matplotlib` as a required package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     url="https://github.com/laserson/squarify",
+    install_requires=["matplotlib"],
 )


### PR DESCRIPTION
This makes sure `squarify.plot` works out of the box.