### PR TITLE
Get cmap from mpl.pyplot

### DIFF
--- a/squarify/__init__.py
+++ b/squarify/__init__.py
@@ -225,10 +225,9 @@ def plot(
         ax = plt.gca()
 
     if color is None:
-        import matplotlib.cm
         import random
 
-        cmap = matplotlib.cm.get_cmap()
+        cmap = plt.get_cmap()
         color = [cmap(random.random()) for i in range(len(sizes))]
 
     if bar_kwargs is None:


### PR DESCRIPTION
This pull request updates the `plot()` function to get the color map from [matplotlib.pyplot](https://matplotlib.org/3.10.1/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib.pyplot.get_cmap) instead of the `matplotlib.cm` module.

There's an odd story for `get_cmap`. It was marked deprecated in the matplotlib [v3.6 docs](https://matplotlib.org/3.6.0/api/cm_api.html#matplotlib.cm.get_cmap). The [v3.7 docs](https://matplotlib.org/3.7.0/api/cm_api.html#matplotlib.cm.get_cmap) say it was deprecated since that version. Then, it was [removed in v3.9](https://github.com/matplotlib/matplotlib/commit/7f23ee15f80c279100f5909ca1d681c575aeb23b) and subsequently [added back in v3.9.1](https://github.com/matplotlib/matplotlib/pull/28355). I just unfortunately happened to have been using v3.9.0 when I went down this rabbit hole. See https://github.com/matplotlib/matplotlib/issues/28349.

 In the end, this is probably a low value change, but the [latest docs](https://matplotlib.org/3.10.1/api/cm_api.html#matplotlib.cm.get_cmap) still have it deprecated so maybe it's future proofing. FWIW this was the intent of #41 as well. @laserson take it or leave it as you please, I'll update my matplotlib version anyway.

Thanks for your great work!